### PR TITLE
HOTFIX: INSTALL TERRAFORM ON LATEST RUNNER

### DIFF
--- a/.github/workflows/prod_pipeline.yml
+++ b/.github/workflows/prod_pipeline.yml
@@ -111,7 +111,10 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
-
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+         terraform_version: "1.5.7"
       - name: Terraform Init
         run: terraform init
         working-directory: terraform
@@ -201,7 +204,10 @@ jobs:
           cloudflare_zone_id = "${{ secrets.CLOUDFLARE_ZONE_ID }}"
           new_relic_license_key = "${{ secrets.NEW_RELIC_LICENSE_KEY }}"
           EOF
-
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+         terraform_version: "1.5.7"
       - name: Terraform Init
         run: terraform init
 

--- a/.github/workflows/stage_pipeline.yml
+++ b/.github/workflows/stage_pipeline.yml
@@ -3,7 +3,7 @@ name: MY STAGING PIPELINE
 on:
   push:
     branches:
-      - hotfix/main
+      - staging
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/stage_pipeline.yml
+++ b/.github/workflows/stage_pipeline.yml
@@ -3,7 +3,7 @@ name: MY STAGING PIPELINE
 on:
   push:
     branches:
-      - staging
+      - hotfix/main
   workflow_dispatch:
 
 permissions:
@@ -114,6 +114,13 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+         terraform_version: "1.5.7"  # You can specify your desired version
+      - name: Terraform Init
+        run: terraform init
+        working-directory: terraform
       - name: Terraform Init
         run: terraform init
         working-directory: terraform

--- a/.github/workflows/stage_pipeline.yml
+++ b/.github/workflows/stage_pipeline.yml
@@ -193,6 +193,10 @@ jobs:
           cloudflare_zone_id = "${{ secrets.CLOUDFLARE_ZONE_ID }}"
           new_relic_license_key = "${{ secrets.NEW_RELIC_LICENSE_KEY }}"
           EOF
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+         terraform_version: "1.5.7"  # You can specify your desired version
       - name: Terraform Init
         run: terraform init
       - name: Terraform Plan


### PR DESCRIPTION
HOTFIX: UBUNTU-LATEST(24.04) COMES WITHOUT TERRAFORM. 
IVE ADDED A STEP IN BPTH STAGING AND PROD PIPELINES TO INSTALL ON THE RUNNERS RESPECTIVELY